### PR TITLE
41 Fix the errors when test are executing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.epam.prejap</groupId>
     <artifactId>tetris</artifactId>
-    <version>0.7</version>
+    <version>0.8</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -18,7 +18,7 @@
         <version.plugin.maven.failsafe>3.0.0-M5</version.plugin.maven.failsafe>
         <!-- dependencies versions -->
         <version.testng>7.3.0</version.testng>
-        <version.mockito>1.10.19</version.mockito>
+        <version.mockito>3.2.4</version.mockito>
     </properties>
 
     <dependencies>
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${version.mockito}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Dependency mockito-all has been replaced with depencency mockito-core. The mockito-core artifact is Mockito's main artifact. “Mockito-all” distribution has been discontinued in Mockito 2.*. The latest GA version of mockito-all is a 1.x version released in 2014. Newer versions of Mockito don't release mockito-all anymore.

@pkierat-epam I have created PR again. The previous one had some git history issues.