### PR TITLE
Fix wrong mainClass in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>
-                            <mainClass>com.epam.prejap.git.tetris.Tetris</mainClass>
+                            <mainClass>com.epam.prejap.tetris.Tetris</mainClass>
                         </manifest>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Replace wrong name of the mainClass to existing one. 
Solve issue #19, now  app runs with following command: 
`java -jar target/tetris-0.1.jar`