### PR TITLE
99 Add a comment on versions naming convention in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,14 @@
         <test.jar.file.location>
             ${project.build.directory}${file.separator}${project.build.finalName}.jar
         </test.jar.file.location>
-        <testng.version>7.4.0</testng.version>
+        <!--
+            Please use this naming convention for plugin and dependency versions: <artifactId.version>
+            Example: maven-jar-plugin -> maven.jar.plugin.version
+            Order of appearance: alphabetical
+        -->
         <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
         <properties.maven.plugin.version>1.0.0</properties.maven.plugin.version>
+        <testng.version>7.4.0</testng.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.epam.prejap</groupId>
     <artifactId>tetris</artifactId>
-    <version>0.7</version>
+    <version>0.8</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This PR **adds a small comment** to the pom.xml regarding the naming convention for plugins and dependencies.

The versions already presented in pom.xml are **sorted** alphabetically (in accordance with this convention)