### PR TITLE
113 Follow-up to S-block

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.epam.prejap</groupId>
     <artifactId>tetris</artifactId>
-    <version>0.10</version>
+    <version>0.11</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -22,10 +22,10 @@
             Example: maven-jar-plugin -> maven.jar.plugin.version
             Order of appearance: alphabetical
         -->
-        <properties.maven.plugin.version>1.0.0</properties.maven.plugin.version>
         <jnativehook.version>2.0.2</jnativehook.version>
-        <testng.version>7.4.0</testng.version>
         <maven.assembly.plugin.version>3.3.0</maven.assembly.plugin.version>
+        <properties.maven.plugin.version>1.0.0</properties.maven.plugin.version>
+        <testng.version>7.4.0</testng.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/epam/prejap/tetris/block/BlockFeed.java
+++ b/src/main/java/com/epam/prejap/tetris/block/BlockFeed.java
@@ -11,10 +11,9 @@ public class BlockFeed {
             HBlock::new,
             IBlock::new,
             OBlock::new,
+            SBlock::new,
             TBlock::new,
-            YBlock::new,
-            IBlock::new,
-            SBlock::new
+            YBlock::new
     );
 
     public BlockFeed() {

--- a/src/test/java/com/epam/prejap/tetris/block/BlocksShapesData.java
+++ b/src/test/java/com/epam/prejap/tetris/block/BlocksShapesData.java
@@ -11,20 +11,31 @@ import java.util.function.Supplier;
  *
  * @author Nikita Pochapynskyi
  */
-public class BlockShapeData {
+public class BlocksShapesData {
 
     /**
      * Contains block's constructor reference and its expected image for each block to be tested.
      * Feel free to add more shapes here (through static init block). They will be tested automatically.
      */
     private static final Map<Supplier<Block>, byte[][]> blocks = new LinkedHashMap<>() {{
-        put(SBlock::new, new byte[][]{
-                {0, 1, 1},
-                {1, 1, 0}
+        put(HBlock::new, new byte[][]{
+                {1, 0, 1},
+                {1, 1, 1},
+                {1, 0, 1}
+        });
+        put(IBlock::new, new byte[][]{
+                {1},
+                {1},
+                {1},
+                {1}
         });
         put(OBlock::new, new byte[][]{
                 {1, 1},
                 {1, 1}
+        });
+        put(SBlock::new, new byte[][]{
+                {0, 1, 1},
+                {1, 1, 0}
         });
         put(TBlock::new, new byte[][]{
                 {1, 1, 1},
@@ -34,17 +45,6 @@ public class BlockShapeData {
                 {1, 0, 1},
                 {0, 1, 0},
                 {0, 1, 0}
-        });
-        put(IBlock::new, new byte[][]{
-                {1},
-                {1},
-                {1},
-                {1}
-        });
-        put(HBlock::new, new byte[][]{
-                {1, 0, 1},
-                {1, 1, 1},
-                {1, 0, 1}
         });
     }};
 

--- a/src/test/java/com/epam/prejap/tetris/block/BlocksShapesTest.java
+++ b/src/test/java/com/epam/prejap/tetris/block/BlocksShapesTest.java
@@ -10,26 +10,26 @@ import static org.testng.Assert.assertEquals;
 
 /**
  * "Generic" test class, to test shapes.
- * Define block class and its expected image in {@link BlockShapeData} class
+ * Define block class and its expected image in {@link BlocksShapesData} class
  * and it will be tested automatically
  *
  * @author Nikita Pochapynskyi
  */
 @Test(groups = "blockShapes")
-public class BlockShapeTest {
+public class BlocksShapesTest {
 
     private final Block block;
     private final byte[][] image;
 
-    @Factory(dataProviderClass = BlockShapeData.class, dataProvider = "blocks")
-    public BlockShapeTest(Block block, byte[][] image) {
+    @Factory(dataProviderClass = BlocksShapesData.class, dataProvider = "blocks")
+    public BlocksShapesTest(Block block, byte[][] image) {
         this.block = block;
         this.image = image;
     }
 
     @DataProvider
     public Iterator<Object[]> dotAtData() {
-        return BlockShapeData.getDotAtDataFor(block.getClass());
+        return BlocksShapesData.getDotAtDataFor(block.getClass());
     }
 
     public void shouldBeRightQtOfRows() {

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -11,7 +11,7 @@
             </run>
         </groups>
         <classes>
-            <class name="com.epam.prejap.tetris.block.BlockShapeTest"/>
+            <class name="com.epam.prejap.tetris.block.BlocksShapesTest"/>
         </classes>
     </test>
     <test verbose="2" name="jar tests">


### PR DESCRIPTION
Follow-up to S-block #113
Solved. Block in BlockFeed and in Test are now in alphabetical order. 
In addition:
- remove duplicated IBlock from BlockFeed,
- refactor test class name to plural.